### PR TITLE
Adding docker-compose.override.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+###> docker ###
+/docker-compose.override.yml
+###< docker ###
+
 ###> symfony/framework-bundle ###
 /.env
 /public/bundles/


### PR DESCRIPTION
In order to externalize the Symfony project from the Docker project, we exclude the docker-compose.override.yml file in the .gitignore file. 
This file will be created according to your needs.